### PR TITLE
Updated the preview for the screenshot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a program to change some of the settings of deepin-kwin   
 
 ### Screenshot
-https://www.dropbox.com/s/qazsw20ydkhnitr/DeepinScreenshot_dde-desktop_20190830082858.png?dl=0
+![image](https://uc60c01c5b932d33431e32f4b5e9.previews.dropboxusercontent.com/p/thumb/AAk4t9WYyki8inUFe-Ti3loCffYnKzm0HUgd0hUDURSCn4TOF-kRoWdImwRMqXrRZa3OWcCpivvvlLMbAQ6Wq76hpdVb-dg7vzGZFyeh82RNoKXEnAg1GHKkfIHwBh4G7uAbLXdwdti2phAz-sB_R32YTONrkXVaaD7ohnWvC6GcIdHrXhdcseKGyvQQWIaJdEh5zdPPD4oXmTASoegLpkaa3K85REG8J9lp_-xdWLS2vvKm4orE_XeVwxYBQwpfnHm5lqJsJd2Oy2F4j4U_A1Y5ecyxudqh5UDKUzEzv6mhRL9sLbtztkhkHLPjRyBw90G2llCk0B3AoKsc76HbgtjN8Y3G1WQCgOs2uTM9KgGc1MiGOJqPG7t63R6b4aSJVPnaEBAFzRUz88qrWaY8nqX3/p.png?fv_content=true&size_mode=5)
 
 ## How to compile and run
 Open a terminal and type the following, \


### PR DESCRIPTION
Dropbox isn´t always ideal for displaying pictures. So, what i´ve did, is copy the actual picture link from Dropbox, instead of the ¨Dropbox link¨ to view and download that picture. If you didn´t understood, that´s because it´s Dropbox.
If you think that link look sketchy, I´ll suggest you to upload your screenshot in the Github repo in itself, or use any Image sharing websites instead. 